### PR TITLE
adding broker resource params: deployment mode and publicly accessible

### DIFF
--- a/aws_mq_broker.broker.tf
+++ b/aws_mq_broker.broker.tf
@@ -6,10 +6,12 @@ resource "aws_mq_broker" "broker" {
     revision = aws_mq_configuration.broker.latest_revision
   }
 
-  engine_type        = var.mq_broker["engine_type"]
-  engine_version     = var.mq_broker["engine_version"]
-  host_instance_type = var.mq_broker["host_instance_type"]
-  security_groups    = [aws_security_group.broker.id]
+  engine_type         = var.mq_broker["engine_type"]
+  engine_version      = var.mq_broker["engine_version"]
+  host_instance_type  = var.mq_broker["host_instance_type"]
+  deployment_mode     = var.mq_broker["deployment_mode"]
+  publicly_accessible = var.mq_broker["publicly_accessible"]
+  security_groups     = [aws_security_group.broker.id]
 
   user {
     username = var.username


### PR DESCRIPTION
Closes #4 

Just a minor change to allow access to two more params from aws_mq_broker resource. Additional lines changed are just aesthetic.

Thanks for the module!